### PR TITLE
Add test harness

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ pipeline:
     environment:
       - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
-      - make 'compose_project_name=docker-janusgraph-${DRONE_BUILD_NUMBER}' test || true
+      - make 'compose_project_name=docker-janusgraph-${DRONE_BUILD_NUMBER}' test
     when:
       event: [pull_request, tag]
   docker-build-and-push:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+DOCKER_IMAGE ?= janusgraph
 
 repo_driver_dynamodb = https://github.com/awslabs/dynamodb-janusgraph-storage-backend.git
 keysize = 4096
@@ -24,7 +25,7 @@ clean:
 deps: deps/dynamodb-janusgraph-storage-backend/
 
 docker: build/janusgraph.zip
-	docker build -t 'janusgraph' .
+	docker build -t '$(DOCKER_IMAGE)' .
 
 run: build/janusgraph.zip .env
 	docker-compose up --build

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -18,7 +18,9 @@ services:
       - "dynamodb"
       - "elasticsearch"
   dynamodb:
-    build: "./deps/dynamodb-janusgraph-storage-backend/src/test/resources/dynamodb-local-docker/"
+    build:
+      context: "."
+      dockerfile: "dynamodb.Dockerfile"
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/shell/ || exit 1"]
       interval: 1s

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,35 @@
+version: '3'
+services:
+  janusgraph:
+    build: "./"
+    environment:
+      - DYNAMODB_ENDPOINT=http://dynamodb:8000
+      - ELASTICSEARCH_HOST=elasticsearch
+      - ELASTICSEARCH_PORT=9200
+      - HTTPS_CRT=${JANUSGRAPH_CRT}
+      - HTTPS_KEY=${JANUSGRAPH_KEY}
+      - LISTEN_PORT=8182
+    healthcheck:
+      test: ["CMD-SHELL", "curl -kf https://localhost:8182/?gremlin=1; if [ $$? -eq 22 ]; then exit 0; else exit 1; fi"]
+      interval: 1s
+      timeout: 20s
+      retries: 20
+    depends_on:
+      - "dynamodb"
+      - "elasticsearch"
+  dynamodb:
+    build: "./deps/dynamodb-janusgraph-storage-backend/src/test/resources/dynamodb-local-docker/"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/shell/ || exit 1"]
+      interval: 1s
+      timeout: 10s
+      retries: 3
+  elasticsearch:
+    image: "elasticsearch:5.6-alpine"
+    environment:
+      - "discovery.type=single-node"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sSf http://localhost:9200/"]
+      interval: 1s
+      timeout: 10s
+      retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,9 @@ services:
       - "dynamodb"
       - "elasticsearch"
   dynamodb:
-    build: "./deps/dynamodb-janusgraph-storage-backend/src/test/resources/dynamodb-local-docker/"
+    build:
+      context: "."
+      dockerfile: "dynamodb.Dockerfile"
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/shell/ || exit 1"]
       interval: 1s

--- a/dynamodb.Dockerfile
+++ b/dynamodb.Dockerfile
@@ -1,0 +1,16 @@
+FROM openjdk:8-jre
+
+RUN apt-get update -y -q \
+ && apt-get upgrade -y -q \
+ && apt-get install -y -q \
+      gzip \
+      sqlite3 \
+      libsqlite3-dev \
+      tar \
+      wget \
+ && mkdir -p /var/dynamodblocal
+
+WORKDIR /var/dynamodblocal
+RUN wget https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz -q -O - | tar -xz
+EXPOSE 8000
+ENTRYPOINT ["java", "-jar", "DynamoDBLocal.jar", "-inMemory"]


### PR DESCRIPTION
Adds a test harness in the form of docker-compose. An enviornment is
brought up then tests are run against it before it is brought down.

For now only a very simple test has been added. (Checking that Gremlin
agrees that 1+1 = 2.) In the future we should add more advanced tests
that test that both backends are working.

Partially addresses #1.