### PR TITLE
Add more env variables for configuring DynamoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Configuration
 The image can be configured by using the following environment variables:
 * **DYNAMODB_REGION**: The DynamoDB region to use. Default: `us-east-1`
 * **DYNAMODB_ENDPOINT**: The DynamoDB endpoint to use. Defaults to the endpoint for the region you select.
+* **DYNAMODB_AWS_ACCESS**: The AWS access key to use for DynamoDB.
+* **DYNAMODB_AWS_SECRET**: The AWS secret key to use for DynamoDB.
 * **ELASTICSEARCH_HOST**: The Elasticsearch host to connect to. Default: `localhost`
 * **ELASTICSEARCH_PORT**: The port on the Elasticsearch host to connect to. Default: `9200`
 * **HTTPS_CRT**: A base64 encoded TLS certificate to be used as the server certificate on the HTTP server.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Configuration
 The image can be configured by using the following environment variables:
 * **DYNAMODB_REGION**: The DynamoDB region to use. Default: `us-east-1`
 * **DYNAMODB_ENDPOINT**: The DynamoDB endpoint to use. Defaults to the endpoint for the region you select.
+* **DYNAMODB_PREFIX**: A prefix to apply to the names of the tables in DynamoDB.
 * **DYNAMODB_AWS_ACCESS**: The AWS access key to use for DynamoDB.
 * **DYNAMODB_AWS_SECRET**: The AWS secret key to use for DynamoDB.
 * **ELASTICSEARCH_HOST**: The Elasticsearch host to connect to. Default: `localhost`

--- a/conf/gremlin-server/janusgraph-backends.properties
+++ b/conf/gremlin-server/janusgraph-backends.properties
@@ -25,7 +25,7 @@ storage.read-time=1 ms
 
 storage.backend=com.amazon.janusgraph.diskstorage.dynamodb.DynamoDBStoreManager
 storage.dynamodb.client.credentials.class-name=com.amazonaws.auth.BasicAWSCredentials
-storage.dynamodb.client.credentials.constructor-args=access,secret
+storage.dynamodb.client.credentials.constructor-args=${DYNAMODB_AWS_ACCESS},${DYNAMODB_AWS_SECRET}
 storage.dynamodb.client.signing-region=${DYNAMODB_REGION}
 
 storage.dynamodb.client.endpoint=${DYNAMODB_ENDPOINT}

--- a/conf/gremlin-server/janusgraph-backends.properties
+++ b/conf/gremlin-server/janusgraph-backends.properties
@@ -31,13 +31,13 @@ storage.dynamodb.client.endpoint=${DYNAMODB_ENDPOINT}
 
 storage.dynamodb.prefix=${DYNAMODB_PREFIX}
 
-storage.dynamodb.stores.edgestore.initial-capacity-read=12
-storage.dynamodb.stores.edgestore.initial-capacity-write=12
+storage.dynamodb.stores.edgestore.initial-capacity-read=1
+storage.dynamodb.stores.edgestore.initial-capacity-write=1
 storage.dynamodb.stores.edgestore.read-rate=1000
 storage.dynamodb.stores.edgestore.write-rate=1000
 
-storage.dynamodb.stores.graphindex.initial-capacity-read=9
-storage.dynamodb.stores.graphindex.initial-capacity-write=9
+storage.dynamodb.stores.graphindex.initial-capacity-read=1
+storage.dynamodb.stores.graphindex.initial-capacity-write=1
 storage.dynamodb.stores.graphindex.read-rate=1000
 storage.dynamodb.stores.graphindex.write-rate=1000
 

--- a/conf/gremlin-server/janusgraph-backends.properties
+++ b/conf/gremlin-server/janusgraph-backends.properties
@@ -27,8 +27,9 @@ storage.backend=com.amazon.janusgraph.diskstorage.dynamodb.DynamoDBStoreManager
 storage.dynamodb.client.credentials.class-name=com.amazonaws.auth.BasicAWSCredentials
 storage.dynamodb.client.credentials.constructor-args=${DYNAMODB_AWS_ACCESS},${DYNAMODB_AWS_SECRET}
 storage.dynamodb.client.signing-region=${DYNAMODB_REGION}
-
 storage.dynamodb.client.endpoint=${DYNAMODB_ENDPOINT}
+
+storage.dynamodb.prefix=${DYNAMODB_PREFIX}
 
 storage.dynamodb.stores.edgestore.initial-capacity-read=12
 storage.dynamodb.stores.edgestore.initial-capacity-write=12


### PR DESCRIPTION
Allows for:
- Setting AWS credentials
- Setting a prefix on the DynamoDB tables

Also minimises the size of any DynamoDB tables created by the driver in order to minimise unintended AWS spend.

Partially addresses #5.